### PR TITLE
Adding encodeURI to avoid server strip values

### DIFF
--- a/hopr-prompt/src/pages/index.tsx
+++ b/hopr-prompt/src/pages/index.tsx
@@ -84,7 +84,7 @@ const Index = () => {
       console.log("API TOKEN", apiToken);
       console.log("Cookies from", Cookies.get("X-Auth-Token"));
       setLoadingServer(true);
-      setServerURL(`${maybeServerURL}?apiToken=${apiToken}`);
+      setServerURL(`${maybeServerURL}?apiToken=${encodeURIComponent(apiToken)}`);
       setInterval(() => {
         setLoadingServer(false);
         setServerURL('')


### PR DESCRIPTION
As otherwise some special characters would fail when read by the server.