### PR TITLE
updated all seasons subgraph to include SS8

### DIFF
--- a/subgraph/packages/subgraph-all-seasons/src/library.ts
+++ b/subgraph/packages/subgraph-all-seasons/src/library.ts
@@ -52,6 +52,7 @@ export function isNullEthValue(value: string): boolean {
  ************************************/
 
 export const StakeSeasonTable = new TypedMap<string, BigInt>();
+StakeSeasonTable.set('0xdc8f03f19986859362d15c3d5ed74f26518870b9', BigInt.fromI32(8))
 StakeSeasonTable.set('0x65c39e6bd97f80b5ae5d2120a47644578fd2b8dc', BigInt.fromI32(7))
 StakeSeasonTable.set('0xa02af160a280957a8881879ee9239a614ab47f0d', BigInt.fromI32(6))
 StakeSeasonTable.set('0xd80fbbfe9d057254d80eebb49f17aca66a238e2d', BigInt.fromI32(5))
@@ -83,7 +84,7 @@ export const getOrInitializeStakeSeason = (stakeContractAddr: string): StakeSeas
     // get season number
     let stakeSeasonNum = StakeSeasonTable.get(stakeContractAddr)
     if (!stakeSeasonNum) {
-      log.error('Cannot find stake season info with address {}',[stakeContractAddr])
+      log.error('Cannot find stake season info with address {}', [stakeContractAddr])
       stakeSeasonNum = zeroBigInt();
     } else {
       log.debug('Stake season {} has number {}', [stakeContractAddr, stakeSeasonNum.toString()])

--- a/subgraph/packages/subgraph-all-seasons/subgraph.yaml
+++ b/subgraph/packages/subgraph-all-seasons/subgraph.yaml
@@ -5,6 +5,41 @@ schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum/contract
+    name: HoprStakeSeason8
+    network: gnosis
+    source:
+      abi: HoprStakeBase
+      address: "0xdc8f03f19986859362d15c3d5ed74f26518870b9"
+      startBlock: 28930303
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - StakingParticipation
+        - StakeSeason
+      abis:
+        - name: HoprStakeBase
+          file: ./abis/HoprStakeBase.json
+      eventHandlers:
+        - event: Claimed(indexed address,indexed uint256)
+          handler: handleClaimed
+        - event: NftAllowed(indexed uint256)
+          handler: handleNftAllowed
+        - event: NftBlocked(indexed uint256)
+          handler: handleNftBlocked
+        - event: Redeemed(indexed address,indexed uint256,indexed bool)
+          handler: handleRedeemed
+        - event: Released(indexed address,indexed uint256)
+          handler: handleReleased
+        - event: RewardFueled(indexed uint256)
+          handler: handleRewardFueled
+        - event: Staked(indexed address,indexed uint256)
+          handler: handleStaked
+        - event: Sync(indexed address,indexed uint256)
+          handler: handleSync
+      file: ./src/staking.ts
+  - kind: ethereum/contract
     name: HoprStakeSeason7
     network: gnosis
     source:


### PR DESCRIPTION
I included the staking season 8 into the all seasons subgraph.

1) Updated the subgraph.yaml file to include staking season 8 
2) Updated the library.ts file to add a table for staking season 8 

I tested that the code of the subgraph generates via execution of 'yarn codegen' as well as that the subgraph builds via execution of 'yarn build'. I deployed the subgraph to my own studio environment to test that it is working. However, it needs to be deployed and published by the Association account that is responsible for funding the subgraph with GRT. 

Question: 
How to choose the correct start block. I choose a recent block. Do we have some guidelines for this? 