### PR TITLE
Deploy subgraphs for dufour and rotsee

### DIFF
--- a/subgraph/packages/subgraph-dufour/README.md
+++ b/subgraph/packages/subgraph-dufour/README.md
@@ -61,6 +61,11 @@ Note:
 - legacy `test` network (with mHOPR) is deployed at version `v0.0.x`
 - `rotsee` network (with wxHOPR) is deployed at version `v0.1.x`
 
+
+## Deployment
+- Rotsee: QmQJMMWn8DWXuoX4B2kEUj4Ld3czrrnVZ4xuFH7Z7v4X8u
+- Dufour: QmU9EryV27sDD9RDRdE6QEvw8QYx5gdp6MSRSxk9j4NG43
+
 ## Query
 
 A sample query: 

--- a/subgraph/packages/subgraph-dufour/README.md
+++ b/subgraph/packages/subgraph-dufour/README.md
@@ -32,7 +32,7 @@ Although Node Safe Registry (NR) primarily registers Safes created by the NodeSt
 
 ```sh
 yarn install && yarn codegen
-export DUFOUR_SUBGRAPH_NAME=subgraph-dufour
+export DUFOUR_SUBGRAPH_NAME=hopr-nodes-dufour
 ```
 
 2. Create a project in Subgraph studio, if not done

--- a/subgraph/packages/subgraph-dufour/networks/dufour-networks.json
+++ b/subgraph/packages/subgraph-dufour/networks/dufour-networks.json
@@ -1,28 +1,28 @@
 {
     "gnosis": {
       "NodeStakeFactory": {
-        "address": "0x791d190b2c95397F4BcE7bD8032FD67dCEA7a5F2",
-        "startBlock": 29690371
+        "address": "0x098B275485c406573D042848D66eb9d63fca311C",
+        "startBlock": 29706814
       },
       "mHoprToken": {
         "address": "0x66225dE86Cac02b32f34992eb3410F59DE416698",
-        "startBlock": 29472596
+        "startBlock": 29706814
       },
       "wxHoprToken": {
         "address": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
-        "startBlock": 29472596
+        "startBlock": 29706814
       },
       "xHoprToken": {
         "address": "0xD057604A14982FE8D88c5fC25Aac3267eA142a08",
-        "startBlock": 29472596
+        "startBlock": 29706814
       },
       "NodeSafeRegistry": {
-        "address": "0x4F7C7dE3BA2B29ED8B2448dF2213cA43f94E45c0",
-        "startBlock": 29690371
+        "address": "0xe15C24a0910311c83aC78B5930d771089E93077b",
+        "startBlock": 29706814
       },
       "NetworkRegistry": {
-        "address": "0x2f3243adC9805F6dd3E01C9E9ED31675A5B16902",
-        "startBlock": 29690371
+        "address": "0x582b4b586168621dAf83bEb2AeADb5fb20F8d50d",
+        "startBlock": 29706814
       }
     }
 }

--- a/subgraph/packages/subgraph-dufour/subgraph.yaml
+++ b/subgraph/packages/subgraph-dufour/subgraph.yaml
@@ -7,8 +7,8 @@ dataSources:
     network: gnosis
     source:
       abi: NodeStakeFactory
-      address: "0xa2e2F71f687914f5DC2010632bC2dEbB1B9FC1D5"
-      startBlock: 29472596
+      address: "0x791d190b2c95397F4BcE7bD8032FD67dCEA7a5F2"
+      startBlock: 29690371
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -103,8 +103,8 @@ dataSources:
     network: gnosis
     source:
       abi: NodeSafeRegistry
-      address: "0x3E7c4720934ff6A9FE122Cb761f36a11E9b848D9"
-      startBlock: 29472596
+      address: "0x4F7C7dE3BA2B29ED8B2448dF2213cA43f94E45c0"
+      startBlock: 29690371
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -132,7 +132,7 @@ dataSources:
     source:
       abi: NetworkRegistry
       address: "0x2f3243adC9805F6dd3E01C9E9ED31675A5B16902"
-      startBlock: 29472596
+      startBlock: 29690371
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7


### PR DESCRIPTION
- Added network config files
- Deployed subgraphs for rotsee and dufour
    - Rotsee: QmQJMMWn8DWXuoX4B2kEUj4Ld3czrrnVZ4xuFH7Z7v4X8u
    - Dufour: QmU9EryV27sDD9RDRdE6QEvw8QYx5gdp6MSRSxk9j4NG43