### PR TITLE
fixed contract address of network registry in rotsee

### DIFF
--- a/subgraph/packages/subgraph-dufour/networks/rotsee-networks.json
+++ b/subgraph/packages/subgraph-dufour/networks/rotsee-networks.json
@@ -1,28 +1,28 @@
 {
-    "gnosis": {
-      "NodeStakeFactory": {
-        "address": "0x791d190b2c95397F4BcE7bD8032FD67dCEA7a5F2",
-        "startBlock": 29690371
-      },
-      "mHoprToken": {
-        "address": "0x66225dE86Cac02b32f34992eb3410F59DE416698",
-        "startBlock": 29472596
-      },
-      "wxHoprToken": {
-        "address": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
-        "startBlock": 29472596
-      },
-      "xHoprToken": {
-        "address": "0xD057604A14982FE8D88c5fC25Aac3267eA142a08",
-        "startBlock": 29472596
-      },
-      "NodeSafeRegistry": {
-        "address": "0x4F7C7dE3BA2B29ED8B2448dF2213cA43f94E45c0",
-        "startBlock": 29690371
-      },
-      "NetworkRegistry": {
-        "address": "0x2f3243adC9805F6dd3E01C9E9ED31675A5B16902",
-        "startBlock": 29690371
-      }
+  "gnosis": {
+    "NodeStakeFactory": {
+      "address": "0x791d190b2c95397F4BcE7bD8032FD67dCEA7a5F2",
+      "startBlock": 29690371
+    },
+    "mHoprToken": {
+      "address": "0x66225dE86Cac02b32f34992eb3410F59DE416698",
+      "startBlock": 29472596
+    },
+    "wxHoprToken": {
+      "address": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
+      "startBlock": 29472596
+    },
+    "xHoprToken": {
+      "address": "0xD057604A14982FE8D88c5fC25Aac3267eA142a08",
+      "startBlock": 29472596
+    },
+    "NodeSafeRegistry": {
+      "address": "0x4F7C7dE3BA2B29ED8B2448dF2213cA43f94E45c0",
+      "startBlock": 29690371
+    },
+    "NetworkRegistry": {
+      "address": "0x15a315E1320cFF0de84671c0139042EE320CE38d",
+      "startBlock": 29690371
     }
+  }
 }

--- a/subgraph/packages/subgraph-dufour/src/constants.ts
+++ b/subgraph/packages/subgraph-dufour/src/constants.ts
@@ -7,10 +7,10 @@ export const ALL_THE_SAFES_KEY = "all_the_safes"
 // network sepcific
 
 // dufour (production)
-export const CHANNELS_CONTRACT_ADDRESS = "0x693Bac5ce61c720dDC68533991Ceb41199D8F8ae"
+// export const CHANNELS_CONTRACT_ADDRESS = "0x693Bac5ce61c720dDC68533991Ceb41199D8F8ae"
 
 // rotsee (staging)
-// export const CHANNELS_CONTRACT_ADDRESS = "0x77C9414043d27fdC98A6A2d73fc77b9b383092a7"
+export const CHANNELS_CONTRACT_ADDRESS = "0x77C9414043d27fdC98A6A2d73fc77b9b383092a7"
 
 // test
 // export const CHANNELS_CONTRACT_ADDRESS = "0x51b0BDA0aF2d760302cA433aDEdd3858f9Bfb4C4"


### PR DESCRIPTION
This PR fixes the network registry contract in rotsee. The correct address for the network registry in rotsee is `0x15a315E1320cFF0de84671c0139042EE320CE38d`. 

This issue prevents the `ct-app` to query the registered nodes from the subgraph. 