### PR TITLE
Keep track of redeemed value by account (node)

### DIFF
--- a/subgraph/packages/subgraph-dufour-channel/schema.graphql
+++ b/subgraph/packages/subgraph-dufour-channel/schema.graphql
@@ -16,6 +16,8 @@ type Account @entity {
   hasAnnounced: Boolean!
   "sum of the channel balances where the account is the source"
   balance: BigDecimal!
+  "total value of the tickets redeemed by the account"
+  redeemedValue: BigDecimal!
 }
 
 enum ChannelStatus {

--- a/subgraph/packages/subgraph-dufour-channel/src/channels.ts
+++ b/subgraph/packages/subgraph-dufour-channel/src/channels.ts
@@ -168,4 +168,10 @@ export function handleTicketRedeemed(event: TicketRedeemed): void {
     channel.ticketIndex = ticket.ticketIndex
 
     channel.save()
+
+    // update account redeemedValue
+    let account = getOrInitiateAccount(channel.destination)
+    account.redeemedValue = account.redeemedValue.plus(ticket.amount)
+
+    account.save()
 }

--- a/subgraph/packages/subgraph-dufour-channel/src/library.ts
+++ b/subgraph/packages/subgraph-dufour-channel/src/library.ts
@@ -84,6 +84,7 @@ export function getOrInitiateAccount(accountId: string): Account {
     account.publicKey = null
     account.fromChannelsCount = zeroBigInt()
     account.toChannelsCount = zeroBigInt()
+    account.redeemedValue = zeroBD()
   }
 
   return account as Account;

--- a/subgraph/packages/subgraph-dufour-channel/subgraph.yaml
+++ b/subgraph/packages/subgraph-dufour-channel/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     source:
       abi: HoprAnnouncements
       address: "0x619eabE23FD0E2291B50a507719aa633fE6069b8"
-      startBlock: 31000000
+      startBlock: 29706820
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -33,7 +33,7 @@ dataSources:
     source:
       abi: HoprChannels
       address: "0x693Bac5ce61c720dDC68533991Ceb41199D8F8ae"
-      startBlock: 31000000
+      startBlock: 29706820
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7


### PR DESCRIPTION
This PR modifies the dufour-channels subgraph to keep track of the amount that a single account redeemed. This is helpful for CT, as it would allows some dynamic economic model parameters, as well as for Products team, where the total amount of rewards received by a node should be displayed in the Hub.