### PR TITLE
Modify `hopr-allocation-on-gnosis` and `hopr-on-mainnet` slugs

### DIFF
--- a/subgraph/packages/hopr-on-mainnet/package.json
+++ b/subgraph/packages/hopr-on-mainnet/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "hopr-on-mainnet",
+  "name": "hopr---mainnet",
   "license": "UNLICENSED",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ hopr-on-mainnet",
-    "create-local": "graph create --node http://localhost:8020/ hopr-on-mainnet",
-    "remove-local": "graph remove --node http://localhost:8020/ hopr-on-mainnet",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 hopr-on-mainnet",
+    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ hopr---mainnet",
+    "create-local": "graph create --node http://localhost:8020/ hopr---mainnet",
+    "remove-local": "graph remove --node http://localhost:8020/ hopr---mainnet",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 hopr---mainnet",
     "test": "graph test"
   },
   "dependencies": {

--- a/subgraph/packages/hopr-on-mainnet/src/mapping.ts
+++ b/subgraph/packages/hopr-on-mainnet/src/mapping.ts
@@ -4,7 +4,7 @@ import {
 import { ADDRESS_ZERO, updateHoprAccount } from "./library"
 
 
-export function handleHoprTransfer(event: HoprTransferEvent): void {
+export function handleTransfert(event: HoprTransferEvent): void {
   let addrFrom = event.params.from
   let addrTo = event.params.to
   let blkNum = event.block.number
@@ -17,4 +17,3 @@ export function handleHoprTransfer(event: HoprTransferEvent): void {
     updateHoprAccount(addrTo, event.params.value, true, blkNum, blkTimeStamp)
   }
 }
-

--- a/subgraph/packages/hopr-on-mainnet/subgraph.yaml
+++ b/subgraph/packages/hopr-on-mainnet/subgraph.yaml
@@ -20,5 +20,5 @@ dataSources:
           file: ./abis/HoprToken.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
-          handler: handleHoprTransfer
+          handler: handleTransfert
       file: ./src/mapping.ts

--- a/subgraph/packages/subgraph-allocations-gnosis/package.json
+++ b/subgraph/packages/subgraph-allocations-gnosis/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "hopr-allocations-on-gnosis",
+  "name": "hopr-allocations---gnosis",
   "license": "UNLICENSED",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/hopr-allocations-on-gnosis",
-    "create-local": "graph create --node http://localhost:8020/hopr-allocations-on-gnosis",
-    "remove-local": "graph remove --node http://localhost:8020/hopr-allocations-on-gnosis",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 hopr-allocations-on-gnosis",
+    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/hopr-allocations---gnosis",
+    "create-local": "graph create --node http://localhost:8020/hopr-allocations---gnosis",
+    "remove-local": "graph remove --node http://localhost:8020/hopr-allocations---gnosis",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 hopr-allocations---gnosis",
     "test": "graph test"
   },
   "dependencies": {


### PR DESCRIPTION
Update the `HOPR Allocation on Gnosis` subgraph slug from `hopr-allocations-on-gnosis` to `hopr-allocations---gnosis` to (hopefully) get a different subgraph ID than for `HOPR on mainnet` subgraph.

Update the `HOPR on Mainnet` subgraph slug from `hopr-on-mainnet` to `hopr--mainnet` to (hopefully) get a different subgraph IDs.

Also changes the handler for HOPR transfer on Mainnet for the `HOPR on mainnet` subgraph to reflect recent changes to the published version of the subgraph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Renamed event handler for transfer events to improve clarity.
	- Updated project names for consistency across deployment commands.

- **Bug Fixes**
	- No functional changes; all core functionalities remain intact despite renaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->